### PR TITLE
Add ElectrumReporter

### DIFF
--- a/lib/bitcoin_accounting.ex
+++ b/lib/bitcoin_accounting.ex
@@ -9,7 +9,7 @@ defmodule BitcoinAccounting do
 
     xpub
     |> XpubManager.entries_for(gap_limit_stop)
-    |> JournalReport.for_xpub()
+    |> JournalReport.from_entries()
   end
 
   def get_address_history(address) do

--- a/lib/bitcoin_accounting.ex
+++ b/lib/bitcoin_accounting.ex
@@ -1,6 +1,6 @@
 defmodule BitcoinAccounting do
   alias BitcoinAccounting.{AddressManager, XpubManager}
-  alias BitcoinAccounting.AddressManager.JournalEntries
+  alias BitcoinAccounting.JournalReport
   @get_book_entries_defaults %{gap_limit_stop: 20}
 
   @spec get_book_entries(binary(), list()) :: %{receive: list(), change: list()}
@@ -9,7 +9,7 @@ defmodule BitcoinAccounting do
 
     xpub
     |> XpubManager.entries_for(gap_limit_stop)
-    |> JournalEntries.for_xpub()
+    |> JournalReport.for_xpub()
   end
 
   def get_address_history(address) do
@@ -17,7 +17,7 @@ defmodule BitcoinAccounting do
     |> AddressManager.history_for()
     |> Map.get(:history)
     |> Enum.map(fn history_item ->
-      JournalEntries.from_transaction_request(history_item, address)
+      JournalReport.from_transaction_request(history_item, address)
     end)
   end
 end

--- a/lib/bitcoin_accounting/address_manager.ex
+++ b/lib/bitcoin_accounting/address_manager.ex
@@ -1,4 +1,6 @@
 defmodule BitcoinAccounting.AddressManager do
+  alias BitcoinAccounting.AddressManager.JournalEntries
+
   def history_for(address_range) when is_list(address_range) do
     Enum.map(address_range, &history_for/1)
   end
@@ -8,12 +10,33 @@ defmodule BitcoinAccounting.AddressManager do
       address
       |> electrum_client().get_address_history()
       |> Enum.map(fn %{txid: transaction_id} ->
-        transaction_id
-        |> electrum_client().get_transaction()
-        |> Map.put(:tx_id, transaction_id)
+        el_transaction =
+          transaction_id
+          |> electrum_client().get_transaction()
+          |> Map.put(:tx_id, transaction_id)
+
+        Map.put(el_transaction, :transaction, add_vouts(el_transaction.transaction, address))
       end)
 
     %{address: address, history: history}
+  end
+
+  defp add_vouts(transaction, address) do
+    Map.put(
+      transaction,
+      :inputs,
+      Enum.map(transaction.inputs, fn input ->
+        vout =
+          input
+          |> Map.get(:txid)
+          |> electrum_client().get_transaction()
+          |> Map.get(:transaction)
+          |> Map.get(:outputs)
+          |> Enum.at(input.vout)
+
+        Map.put(input, :vout_details, hd(JournalEntries.classify([vout], address)))
+      end)
+    )
   end
 
   defp electrum_client() do

--- a/lib/bitcoin_accounting/address_manager.ex
+++ b/lib/bitcoin_accounting/address_manager.ex
@@ -1,6 +1,6 @@
 defmodule BitcoinAccounting.AddressManager do
   alias BitcoinLib.Address
-  alias BitcoinAccounting.AddressManager.JournalEntries.OutputManager
+  alias BitcoinAccounting.AddressManager.OutputManager
 
   def history_for(address_range) when is_list(address_range) do
     Enum.map(address_range, &history_for/1)

--- a/lib/bitcoin_accounting/address_manager.ex
+++ b/lib/bitcoin_accounting/address_manager.ex
@@ -11,15 +11,31 @@ defmodule BitcoinAccounting.AddressManager do
       address
       |> electrum_client().get_address_history()
       |> Enum.map(fn %{txid: transaction_id} ->
-        el_transaction =
           transaction_id
           |> electrum_client().get_transaction()
           |> Map.put(:tx_id, transaction_id)
-
-        Map.put(el_transaction, :transaction, add_vouts(el_transaction.transaction, address))
+          |> add_vouts_to_transaction_inputs(address)
       end)
 
     %{address: address, history: history}
+  end
+
+  def classify(outputs, address) do
+    {:ok, _, _key_type, network} = Address.destructure(address)
+
+    outputs
+    |> Enum.map(fn output ->
+      {script_type, script_value, address} = OutputManager.identify_script_type(output, network)
+
+      output
+      |> Map.put(:script_type, script_type)
+      |> Map.put(:script_value, script_value)
+      |> Map.put(:address, address)
+    end)
+  end
+
+  defp add_vouts_to_transaction_inputs(transaction, address) do
+    Map.put(transaction, :transaction, add_vouts(transaction.transaction, address))
   end
 
   defp add_vouts(transaction, address) do
@@ -38,20 +54,6 @@ defmodule BitcoinAccounting.AddressManager do
         Map.put(input, :vout_details, hd(classify([vout], address)))
       end)
     )
-  end
-
-  def classify(outputs, address) do
-    {:ok, _, _key_type, network} = Address.destructure(address)
-
-    outputs
-    |> Enum.map(fn output ->
-      {script_type, script_value, address} = OutputManager.identify_script_type(output, network)
-
-      output
-      |> Map.put(:script_type, script_type)
-      |> Map.put(:script_value, script_value)
-      |> Map.put(:address, address)
-    end)
   end
 
   defp electrum_client() do

--- a/lib/bitcoin_accounting/address_manager/journal_entries.ex
+++ b/lib/bitcoin_accounting/address_manager/journal_entries.ex
@@ -59,16 +59,7 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
   end
 
   defp extract_inputs(transaction) do
-    transaction
-    |> Map.get(:inputs)
-    |> Enum.map(fn input ->
-      input
-      |> Map.get(:txid)
-      |> electrum_client().get_transaction()
-      |> Map.get(:transaction)
-      |> Map.get(:outputs)
-      |> Enum.at(input.vout)
-    end)
+    Enum.map(transaction.inputs, & &1.vout_details)
   end
 
   defp extract_outputs(transaction) do
@@ -95,9 +86,5 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
 
   defp get_value(inputs) do
     Enum.map(inputs, & &1.value)
-  end
-
-  defp electrum_client() do
-    Application.get_env(:bitcoin_accounting, :electrum_client)
   end
 end

--- a/lib/bitcoin_accounting/address_manager/journal_entries.ex
+++ b/lib/bitcoin_accounting/address_manager/journal_entries.ex
@@ -1,6 +1,6 @@
 defmodule BitcoinAccounting.AddressManager.JournalEntries do
-  alias BitcoinLib.{Address, Transaction}
-  alias BitcoinAccounting.AddressManager.JournalEntries.OutputManager
+  alias BitcoinLib.Transaction
+  alias BitcoinAccounting.AddressManager
 
   def for_xpub(entries) do
     %{
@@ -45,7 +45,7 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
   defp get_debits(transaction, address) do
     transaction
     |> extract_inputs()
-    |> classify(address)
+    |> AddressManager.classify(address)
     |> filter_address(address)
     |> get_value()
   end
@@ -53,7 +53,7 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
   defp get_credits(transaction, address) do
     transaction
     |> extract_outputs()
-    |> classify(address)
+    |> AddressManager.classify(address)
     |> filter_address(address)
     |> get_value()
   end
@@ -64,20 +64,6 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
 
   defp extract_outputs(transaction) do
     Map.get(transaction, :outputs)
-  end
-
-  def classify(outputs, address) do
-    {:ok, _, _key_type, network} = Address.destructure(address)
-
-    outputs
-    |> Enum.map(fn output ->
-      {script_type, script_value, address} = OutputManager.identify_script_type(output, network)
-
-      output
-      |> Map.put(:script_type, script_type)
-      |> Map.put(:script_value, script_value)
-      |> Map.put(:address, address)
-    end)
   end
 
   defp filter_address(inputs, address) do

--- a/lib/bitcoin_accounting/address_manager/journal_entries.ex
+++ b/lib/bitcoin_accounting/address_manager/journal_entries.ex
@@ -9,6 +9,16 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
     }
   end
 
+  defp for_xpub_entry(%{address: address, history: history}) do
+    %{
+      address: address,
+      history:
+        Enum.map(history, fn history_item ->
+          from_transaction_request(history_item, address)
+        end)
+    }
+  end
+
   @spec from_transaction_request(map(), binary()) :: map()
   def from_transaction_request(
         %{
@@ -65,7 +75,7 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
     Map.get(transaction, :outputs)
   end
 
-  defp classify(outputs, address) do
+  def classify(outputs, address) do
     {:ok, _, _key_type, network} = Address.destructure(address)
 
     outputs
@@ -85,16 +95,6 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries do
 
   defp get_value(inputs) do
     Enum.map(inputs, & &1.value)
-  end
-
-  defp for_xpub_entry(%{address: address, history: history}) do
-    %{
-      address: address,
-      history:
-        Enum.map(history, fn history_item ->
-          from_transaction_request(history_item, address)
-        end)
-    }
   end
 
   defp electrum_client() do

--- a/lib/bitcoin_accounting/address_manager/output_manager.ex
+++ b/lib/bitcoin_accounting/address_manager/output_manager.ex
@@ -1,4 +1,4 @@
-defmodule BitcoinAccounting.AddressManager.JournalEntries.OutputManager do
+defmodule BitcoinAccounting.AddressManager.OutputManager do
   require Logger
 
   alias BitcoinLib.{Address, Script}
@@ -39,7 +39,7 @@ defmodule BitcoinAccounting.AddressManager.JournalEntries.OutputManager do
   defp add_address({:p2wsh, script_hash}, network) do
     address =
       script_hash
-      |> Address.P2SH.from_script_hash(network)
+      |> Address.P2WSH.from_script_hash(network)
 
     {:p2wsh, script_hash, address}
   end

--- a/lib/bitcoin_accounting/electrum_report.ex
+++ b/lib/bitcoin_accounting/electrum_report.ex
@@ -27,12 +27,12 @@ defmodule BitcoinAccounting.ElectrumReport do
     }
   end
 
-  def operations(entry_history, address, changes) do
+  defp operations(entry_history, address, changes) do
     input_operations(entry_history.transaction, address, changes) ++
       output_operations(entry_history.transaction, address, changes)
   end
 
-  def input_operations(transaction, address, changes) do
+  defp input_operations(transaction, address, changes) do
     transaction
     |> Map.get(:inputs)
     |> then(fn inputs ->
@@ -50,7 +50,7 @@ defmodule BitcoinAccounting.ElectrumReport do
     end)
   end
 
-  def output_operations(transaction, address, changes) do
+  defp output_operations(transaction, address, changes) do
     transaction
     |> Map.get(:outputs)
     |> AddressManager.classify(address)
@@ -66,7 +66,7 @@ defmodule BitcoinAccounting.ElectrumReport do
     end)
   end
 
-  def operation_type(output, changes, address) do
+  defp operation_type(output, changes, address) do
     if output.address == address or output.address in addresses_in(changes) do
       :self
     else
@@ -74,7 +74,7 @@ defmodule BitcoinAccounting.ElectrumReport do
     end
   end
 
-  def sent_by(entry_history, receives, changes) do
+  defp sent_by(entry_history, receives, changes) do
     sender_addresses = Enum.map(entry_history.transaction.inputs, & &1.vout_details.address)
 
     my_inputs =

--- a/lib/bitcoin_accounting/electrum_report.ex
+++ b/lib/bitcoin_accounting/electrum_report.ex
@@ -1,0 +1,106 @@
+defmodule BitcoinAccounting.ElectrumReport do
+  alias BitcoinAccounting.XpubManager
+  alias BitcoinAccounting.AddressManager.JournalEntries
+
+  def for(xpub, gap_limit_stop \\ 20) do
+    %{change: changes, receive: receives} = XpubManager.entries_for(xpub, gap_limit_stop)
+
+    Enum.map(receives, fn rcv -> to_entries(rcv, receives, changes) end)
+  end
+
+  def to_entries(rcv, receives, changes) do
+    %{
+      address: rcv.address,
+      entries:
+        Enum.map(rcv.history, fn entry_history ->
+          ops = operations(entry_history, rcv.address, changes)
+
+          %{
+            txid: entry_history.tx_id,
+            time: entry_history.time,
+            confirmations: entry_history.confirmations,
+            operations: ops,
+            fee: fee(ops),
+            sent_by: sent_by(entry_history, receives, changes)
+          }
+        end)
+    }
+  end
+
+  def operations(entry_history, address, changes) do
+    input_operations(entry_history.transaction, address, changes) ++
+      output_operations(entry_history.transaction, address, changes)
+  end
+
+  def input_operations(transaction, address, changes) do
+    transaction
+    |> Map.get(:inputs)
+    |> then(fn inputs ->
+      Enum.map(inputs, &{&1, hd(JournalEntries.classify([&1.vout_details], address))})
+    end)
+    |> Enum.reduce([], fn {_input, output}, acc ->
+      operation = %{
+        direction: :send,
+        value: output.value,
+        address: output.address,
+        type: operation_type(output, changes, address)
+      }
+
+      [operation | acc]
+    end)
+  end
+
+  def output_operations(transaction, address, changes) do
+    transaction
+    |> Map.get(:outputs)
+    |> JournalEntries.classify(address)
+    |> Enum.reduce([], fn output, acc ->
+      operation = %{
+        direction: :receive,
+        value: output.value,
+        address: output.address,
+        type: operation_type(output, changes, address)
+      }
+
+      [operation | acc]
+    end)
+  end
+
+  def operation_type(output, changes, address) do
+    if output.address == address or output.address in addresses_in(changes) do
+      :self
+    else
+      :external
+    end
+  end
+
+  def sent_by(entry_history, receives, changes) do
+    sender_addresses = Enum.map(entry_history.transaction.inputs, & &1.vout_details.address)
+
+    my_inputs =
+      Enum.any?(sender_addresses, fn sender_address ->
+        sender_address in addresses_in(changes) or sender_address in addresses_in(receives)
+      end)
+
+    if my_inputs do
+      :myself
+    else
+      :external
+    end
+  end
+
+  defp addresses_in(section) do
+    Enum.map(section, & &1.address)
+  end
+
+  defp fee(ops) do
+    if Enum.any?(ops, &(&1.direction == :send)) do
+      ops
+      |> Enum.map(&if(&1.direction == :send, do: &1.value * -1, else: &1.value))
+      |> Enum.sum()
+      |> abs()
+    else
+      nil
+    end
+  end
+end

--- a/lib/bitcoin_accounting/journal_report.ex
+++ b/lib/bitcoin_accounting/journal_report.ex
@@ -1,4 +1,4 @@
-defmodule BitcoinAccounting.AddressManager.JournalEntries do
+defmodule BitcoinAccounting.JournalReport do
   alias BitcoinLib.Transaction
   alias BitcoinAccounting.AddressManager
 

--- a/lib/bitcoin_accounting/journal_report.ex
+++ b/lib/bitcoin_accounting/journal_report.ex
@@ -2,14 +2,14 @@ defmodule BitcoinAccounting.JournalReport do
   alias BitcoinLib.Transaction
   alias BitcoinAccounting.AddressManager
 
-  def for_xpub(entries) do
+  def from_entries(entries) do
     %{
-      change: Enum.map(entries.change, &for_xpub_entry/1),
-      receive: Enum.map(entries.receive, &for_xpub_entry/1)
+      change: Enum.map(entries.change, &from_address_entry/1),
+      receive: Enum.map(entries.receive, &from_address_entry/1)
     }
   end
 
-  defp for_xpub_entry(%{address: address, history: history}) do
+  defp from_address_entry(%{address: address, history: history}) do
     %{
       address: address,
       history:

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BitcoinAccounting.MixProject do
   use Mix.Project
 
-  @version "0.1.21"
+  @version "0.1.22"
 
   def project do
     [

--- a/test/integration/address_history_test.exs
+++ b/test/integration/address_history_test.exs
@@ -1,4 +1,4 @@
-defmodule  BitcoinAccounting.Integration.AddressHistoryTest do
+defmodule BitcoinAccounting.Integration.AddressHistoryTest do
   use ExUnit.Case, async: false
 
   setup do

--- a/test/integration/book_entries_test.exs
+++ b/test/integration/book_entries_test.exs
@@ -8,7 +8,7 @@ defmodule BitcoinAccounting.Integration.BookEntriesTest do
       Application.put_env(:bitcoin_accounting, :electrum_client, ElectrumClientMock)
     end)
 
-    ip = System.fetch_env!("LB_ELECTRUM_CLIENT_IP") |> IO.inspect()
+    ip = System.fetch_env!("LB_ELECTRUM_CLIENT_IP")
     port = System.fetch_env!("LB_ELECTRUM_CLIENT_PORT") |> Integer.parse() |> elem(0)
 
     start_supervised!(%{

--- a/test/integration/book_entries_test.exs
+++ b/test/integration/book_entries_test.exs
@@ -8,7 +8,7 @@ defmodule BitcoinAccounting.Integration.BookEntriesTest do
       Application.put_env(:bitcoin_accounting, :electrum_client, ElectrumClientMock)
     end)
 
-    ip = System.fetch_env!("LB_ELECTRUM_CLIENT_IP")
+    ip = System.fetch_env!("LB_ELECTRUM_CLIENT_IP") |> IO.inspect()
     port = System.fetch_env!("LB_ELECTRUM_CLIENT_PORT") |> Integer.parse() |> elem(0)
 
     start_supervised!(%{

--- a/test/integration/book_entries_test.exs
+++ b/test/integration/book_entries_test.exs
@@ -1,4 +1,4 @@
-defmodule  BitcoinAccounting.Integration.BookEntriesTest do
+defmodule BitcoinAccounting.Integration.BookEntriesTest do
   use ExUnit.Case, async: false
 
   setup do

--- a/test/integration/electrum_reporter_test.exs
+++ b/test/integration/electrum_reporter_test.exs
@@ -1,0 +1,191 @@
+defmodule BitcoinAccounting.ElectrumReporterTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    Application.put_env(:bitcoin_accounting, :electrum_client, ElectrumClient)
+
+    on_exit(fn ->
+      Application.put_env(:bitcoin_accounting, :electrum_client, ElectrumClientMock)
+    end)
+
+    ip = System.fetch_env!("LB_ELECTRUM_CLIENT_IP")
+    port = System.fetch_env!("LB_ELECTRUM_CLIENT_PORT") |> Integer.parse() |> elem(0)
+
+    start_supervised!(%{
+      id: ElectrumClient,
+      start: {ElectrumClient, :start_link, [ip, port]}
+    })
+
+    :ok
+  end
+
+  @tag :integration
+  test "returns electrum-styled report" do
+    assert [
+             %{
+               address: "bc1qx9628q2uvteaa9k992rp8unqme48xk8n7x0fjq",
+               entries: [
+                 %{
+                   confirmations: confirmations,
+                   fee: 143,
+                   operations: [
+                     %{
+                       address: "bc1q4zyj34hmq0hqzg7sudq8evyfx4s8kpznpjtdcj",
+                       direction: :send,
+                       type: :external,
+                       value: 66278
+                     },
+                     %{
+                       address: "bc1q58sxp4tdynmhgtaxgu5fmweau70ng7jhumlf6z",
+                       direction: :receive,
+                       type: :external,
+                       value: 6135
+                     },
+                     %{
+                       address: "bc1qx9628q2uvteaa9k992rp8unqme48xk8n7x0fjq",
+                       direction: :receive,
+                       type: :self,
+                       value: 60000
+                     }
+                   ],
+                   sent_by: :external,
+                   time: ~U[2022-11-10 02:36:27Z],
+                   txid: "3f5dcd03d4cda0e161cb18a24228cb3aae009c8db750d0614e9faf2577a194a6"
+                 },
+                 %{
+                   confirmations: _,
+                   fee: 200,
+                   operations: [
+                     %{
+                       address: "bc1qx9628q2uvteaa9k992rp8unqme48xk8n7x0fjq",
+                       direction: :send,
+                       type: :self,
+                       value: 60000
+                     },
+                     %{
+                       address: "bc1qcpq4nr9z8r02xd7vsg74fzzerr460fljdz2hvp",
+                       direction: :receive,
+                       type: :external,
+                       value: 30000
+                     },
+                     %{
+                       address: "bc1qraquj0s8sz9s57l7rdgqrg5j0u6rr7ek7kp0x4",
+                       direction: :receive,
+                       type: :self,
+                       value: 29800
+                     }
+                   ],
+                   sent_by: :myself,
+                   time: ~U[2022-11-10 02:36:27Z],
+                   txid: "e445e3dd9828dd61b2b5ae144205d7038d8fb9ab1cb991f5a1bc6b387660ba81"
+                 },
+                 %{
+                   confirmations: _,
+                   fee: 200,
+                   operations: [
+                     %{
+                       address: "bc1qraquj0s8sz9s57l7rdgqrg5j0u6rr7ek7kp0x4",
+                       direction: :send,
+                       type: :self,
+                       value: 29800
+                     },
+                     %{
+                       address: "bc1qx9628q2uvteaa9k992rp8unqme48xk8n7x0fjq",
+                       direction: :receive,
+                       type: :self,
+                       value: 20000
+                     },
+                     %{
+                       address: "bc1qcshhqc3qnztrl9yqd0dyphswqkgwkatcnetctm",
+                       direction: :receive,
+                       type: :self,
+                       value: 9600
+                     }
+                   ],
+                   sent_by: :myself,
+                   time: ~U[2022-11-11 01:31:11Z],
+                   txid: "97b6e12a670ea61cb5e397af1f7049f6b8b39318506bb9e4e2c5c3f2e0b1b035"
+                 },
+                 %{
+                   confirmations: _,
+                   fee: 200,
+                   operations: [
+                     %{
+                       address: "bc1qx9628q2uvteaa9k992rp8unqme48xk8n7x0fjq",
+                       direction: :send,
+                       type: :self,
+                       value: 20000
+                     },
+                     %{
+                       address: "bc1q0qqlc7fms63asxqptz8lkneufvglwpqf7fp2qs",
+                       direction: :receive,
+                       type: :self,
+                       value: 8800
+                     },
+                     %{
+                       address: "Ba2CccgoJ1W2DqtLpSux9qWk3y9Fj3u3gz2yvSd3kK8RZ1SbZ9",
+                       direction: :receive,
+                       type: :external,
+                       value: 6000
+                     },
+                     %{
+                       address: "bc1qzwll7ttd6q4csdl32mr0nlsw5umrmau4es49qe",
+                       direction: :receive,
+                       type: :external,
+                       value: 5000
+                     }
+                   ],
+                   sent_by: :myself,
+                   time: ~U[2022-11-12 22:58:55Z],
+                   txid: "f318dd60cc36fb1238e39abf697b471881ed811f2f66b0bdeed15e29d3032c76"
+                 }
+               ]
+             },
+             %{address: "bc1q6czq8kzp9ma6mnchnwx2rrl6rc89g5j946s2xu", entries: []},
+             %{address: "bc1q7zyyhjx3664d00km5evdnnn04fjdqun94wac4x", entries: []},
+             %{address: "bc1q60qe9q602wt04dfmgjvnefhygudhgyp9pla8ta", entries: []},
+             %{address: "bc1qhptec2x9j7kpmkscxglscxnlj8hpdk4c3rfqpj", entries: []},
+             %{address: "bc1qu7s0jpnt0nuqac0wdvhj3kkrhgdqg574uzzuz4", entries: []},
+             %{address: "bc1qpuxm23rf5wd996xl7lv2s9dywm4vqdp954j2wx", entries: []},
+             %{address: "bc1qznuz9ly0m6484z9wl7uwk55yj6fp9pvqc2pjh0", entries: []},
+             %{address: "bc1qr3a7euk4sd7wv44r7mn5qhachhya49rgezrner", entries: []},
+             %{address: "bc1q8kw86hwvft8nqgcdzmamahscra7lwq265msgwh", entries: []},
+             %{address: "bc1q9r53pqlgv2n7z8e6u0lp54z7qv7arxl6pmx7h7", entries: []},
+             %{address: "bc1qpd9tlpy3tl0ll32wsrw4x6s904f64xtqged6mt", entries: []},
+             %{address: "bc1qvlhqlqjar367snz6kj3z3nzrlqzaxx5j66zz4m", entries: []},
+             %{address: "bc1qh2tzf8fwnxwudjaumlmhh3x6pprput04q33efx", entries: []},
+             %{address: "bc1qurkq6jl37fscag76l0l74w8lnevh6jh9rqgqfe", entries: []},
+             %{address: "bc1q9nemx3q3fzpgvfynktr3va4ecy2yyk87a2z90q", entries: []},
+             %{address: "bc1q80k5w4ld7wm3zqhnk2t4jwet668wyqqxw97p4s", entries: []},
+             %{address: "bc1qqtmtwrc632z4npq5ql0279c46lmac967jpwvsw", entries: []},
+             %{address: "bc1qxcf0hezju3d4tp0ckemjkv4v70ezl8y55tpzfu", entries: []},
+             %{address: "bc1qn69ay5255c89epnkayh9tj67rcdysxq3x3rjx5", entries: []},
+             %{address: "bc1qtxs2txu428cm8lpdjfxr6r7usrcju8aj5n8smz", entries: []},
+             %{address: "bc1qvndlrkgr8n65ufxnvc5hc0e2hg7hug2ffm9mc4", entries: []},
+             %{address: "bc1qvlhta3vmzvwy6qure52qxlfqpkmk5mdzjrxerc", entries: []},
+             %{address: "bc1qejqpy9845etw0svn5dehgq46qjxvxpeyhg380u", entries: []},
+             %{address: "bc1qhuj2ecknl8gqm2x5qp3jk7de0ul6z4uj63ytex", entries: []},
+             %{address: "bc1q679yyerem6jywns0g6u804d27dyne0kphp5gkd", entries: []},
+             %{address: "bc1qaqtfj8cd2v7v6p272nqjpzpkfy7hp5hjcp6tdd", entries: []},
+             %{address: "bc1qg3975n7mx6p56asnvncs4cq29x6xuvwny6ghmv", entries: []},
+             %{address: "bc1q0qgw0jgeqg0ujc6jn5r5wmqv5fpkchud6vd3f7", entries: []},
+             %{address: "bc1qfg6hctzy8e6a36edcq73ws8p75fclfrp6udj90", entries: []},
+             %{address: "bc1q6al9ctk6vxwxqq8tymqx0y743hustssapea4z7", entries: []},
+             %{address: "bc1q2zy60zlqtte42dnls555vsv4ugs74gh6s8f9ty", entries: []},
+             %{address: "bc1qvsjaf6geey00nxuaper7jl5qvafvfur522k7fh", entries: []},
+             %{address: "bc1qzuxvydqtn7apfq9an9d4cvreat382q4dutnknv", entries: []},
+             %{address: "bc1qe8xj4uqrwk5r5jx6cpkqkwgfeaxhwvhpfv4xzr", entries: []},
+             %{address: "bc1qa86xvaw82zff5munn3uschug8s62m8lznmsdjl", entries: []},
+             %{address: "bc1qpkwy2r0uh034dddlnquuf930hfe88m3pfvehf3", entries: []},
+             %{address: "bc1q39nms9wkqcyf7nde8jwatadnzzntzr99a6rmcz", entries: []},
+             %{address: "bc1qhnwfycw4jsqmxcvr0qw7hagcnutgfrp8gk6pfm", entries: []},
+             %{address: "bc1qlmdp9k0dqjhkrte0xmhw6rtu8l7mzg578anxzw", entries: []}
+           ] =
+             BitcoinAccounting.ElectrumReport.for(
+               "zpub6nMFHiw6cmjijjGr7V9dpdUWoKkcvbL7pzRxdgZ1q1R2SfBb5Az6F2PWmHZoENT3spQfHTrdAeQRQ6bdyu3mCqtN1jYkEyYQvvvgAhaBaHG",
+               20
+             )
+
+    assert confirmations > 829
+  end
+end

--- a/test/integration/electrum_reporter_test.exs
+++ b/test/integration/electrum_reporter_test.exs
@@ -123,7 +123,7 @@ defmodule BitcoinAccounting.ElectrumReporterTest do
                        value: 8800
                      },
                      %{
-                       address: "Ba2CccgoJ1W2DqtLpSux9qWk3y9Fj3u3gz2yvSd3kK8RZ1SbZ9",
+                       address: "bc1qdlcyqx907w7nyryfut5vn4p8fe4su7qfwhxnvjqsyw0vc77czw9q6d8zkl",
                        direction: :receive,
                        type: :external,
                        value: 6000

--- a/test/lib/address_manager/journal_entries_test.exs
+++ b/test/lib/address_manager/journal_entries_test.exs
@@ -7,12 +7,6 @@ defmodule BitcoinAccounting.AddressManager.JournalEntriesTest do
 
   describe "from_transaction_request/2" do
     test "calculate debits" do
-      expect(ElectrumClientMock, :get_transaction, fn expected_address ->
-        assert expected_address == transaction_input_fixture().transaction.id
-
-        transaction_input_fixture()
-      end)
-
       assert JournalEntries.from_transaction_request(transaction_fixture(), "12CL4K2eVqj7hQTix7dM7CVHCkpP17Pry3") == %{
                confirmations: 396_000,
                credits: [],
@@ -24,7 +18,7 @@ defmodule BitcoinAccounting.AddressManager.JournalEntriesTest do
   end
 
   defp transaction_fixture() do
-    %{
+    tx = %{
       block_hash: "000000000000000005d682a39582e30549cfde3aff956d8f6e6cd3f181aa581a",
       confirmations: 396_000,
       time: ~U[2015-07-17 17:10:05Z],
@@ -66,62 +60,24 @@ defmodule BitcoinAccounting.AddressManager.JournalEntriesTest do
       },
       vsize: 192
     }
+
+    update_in(tx, [:transaction, Access.key!(:inputs), Access.at!(0)], fn input ->
+      Map.put(input, :vout_details, vout_details())
+    end)
   end
 
-  defp transaction_input_fixture() do
-    %{
-      block_hash: "00000000000000000a310e2c1148f95e6c32c0d9438b9a30f24837ede6c3c136",
-      confirmations: 396_010,
-      time: ~U[2015-07-17 16:22:20Z],
-      transaction: %BitcoinLib.Transaction{
-        version: 1,
-        id: "8615c3852c43074c1b335650ffe08428b0760bc30416f7a7ad8c90a01f77f4a5",
-        inputs: [
-          %BitcoinLib.Transaction.Input{
-            txid: "7e6ddcf959ee85e23823649fed5242f47e700f7917e82a402774dea2796360a6",
-            vout: 1,
-            script_sig: [
-              %BitcoinLib.Script.Opcodes.Data{
-                value:
-                  <<0x304402202181227DDAB08A931E4C46D20FE6015056E9EF7BF7D038558EC3C4F49A100BEF022011BFF29901C46AF7FA3229189BD74FC6F8C4E9C876B740F537C262CFBF3598B401::568>>
-              },
-              %BitcoinLib.Script.Opcodes.Data{
-                value: <<0x03C3630E476B5878A0C212671B2984C4D1D87730A2316A916E2E19E75881A701DD::264>>
-              }
-            ],
-            sequence: 4_294_967_295
-          }
-        ],
-        outputs: [
-          %BitcoinLib.Transaction.Output{
-            value: 37533,
-            script_pub_key: [
-              %BitcoinLib.Script.Opcodes.Stack.Dup{},
-              %BitcoinLib.Script.Opcodes.Crypto.Hash160{},
-              %BitcoinLib.Script.Opcodes.Data{value: <<0x06D6FF37AD15C672F57AF90081C51CC142EAF204::160>>},
-              %BitcoinLib.Script.Opcodes.BitwiseLogic.EqualVerify{},
-              %BitcoinLib.Script.Opcodes.Crypto.CheckSig{
-                script: <<0x76A91406D6FF37AD15C672F57AF90081C51CC142EAF20488AC::200>>
-              }
-            ]
-          },
-          %BitcoinLib.Transaction.Output{
-            value: 17936,
-            script_pub_key: [
-              %BitcoinLib.Script.Opcodes.Stack.Dup{},
-              %BitcoinLib.Script.Opcodes.Crypto.Hash160{},
-              %BitcoinLib.Script.Opcodes.Data{value: <<0x0D1C9C02A7BE9BA8B8842804FEB961481CE6561B::160>>},
-              %BitcoinLib.Script.Opcodes.BitwiseLogic.EqualVerify{},
-              %BitcoinLib.Script.Opcodes.Crypto.CheckSig{
-                script: <<0x76A9140D1C9C02A7BE9BA8B8842804FEB961481CE6561B88AC::200>>
-              }
-            ]
-          }
-        ],
-        locktime: 0,
-        witness: []
-      },
-      vsize: 225
+  defp vout_details() do
+    %BitcoinLib.Transaction.Output{
+      value: 17936,
+      script_pub_key: [
+        %BitcoinLib.Script.Opcodes.Stack.Dup{},
+        %BitcoinLib.Script.Opcodes.Crypto.Hash160{},
+        %BitcoinLib.Script.Opcodes.Data{value: <<0x0D1C9C02A7BE9BA8B8842804FEB961481CE6561B::160>>},
+        %BitcoinLib.Script.Opcodes.BitwiseLogic.EqualVerify{},
+        %BitcoinLib.Script.Opcodes.Crypto.CheckSig{
+          script: <<0x76A9140D1C9C02A7BE9BA8B8842804FEB961481CE6561B88AC::200>>
+        }
+      ]
     }
   end
 end

--- a/test/lib/journal_entries_test.exs
+++ b/test/lib/journal_entries_test.exs
@@ -1,13 +1,13 @@
-defmodule BitcoinAccounting.AddressManager.JournalEntriesTest do
+defmodule BitcoinAccounting.JournalReportTest do
   use ExUnit.Case, async: false
   import Hammox
-  alias BitcoinAccounting.AddressManager.JournalEntries
+  alias BitcoinAccounting.JournalReport
 
   setup :verify_on_exit!
 
   describe "from_transaction_request/2" do
     test "calculate debits" do
-      assert JournalEntries.from_transaction_request(transaction_fixture(), "12CL4K2eVqj7hQTix7dM7CVHCkpP17Pry3") == %{
+      assert JournalReport.from_transaction_request(transaction_fixture(), "12CL4K2eVqj7hQTix7dM7CVHCkpP17Pry3") == %{
                confirmations: 396_000,
                credits: [],
                debits: [17936],


### PR DESCRIPTION
- Move data gathering responsibility to `XpubManager.entries_for/2`. Now it returns the complete dataset that can be transformed into different representations
-  Add  `BitcoinAccounting.ElectrumReport` capable of producing Electrum-like reports 

I've pulled `classify` into  `AddressManager` https://github.com/RooSoft/bitcoin_accounting/pull/4/files#diff-ed49b4e3a232dc19dc7bd36ececa3362c8e3d86ce74a68943e31f4e3e93a54c3R43, not sure if it's the best place for it to be. 